### PR TITLE
Fixed UI rendering on Android VR

### DIFF
--- a/Packages/idv.jlchntoz.vrcw-foundation/Shaders/UI-Modified.shader
+++ b/Packages/idv.jlchntoz.vrcw-foundation/Shaders/UI-Modified.shader
@@ -62,6 +62,8 @@ Shader "UI/Modified" {
             #pragma geometry geom
             #pragma fragment frag
             #pragma target 4.0
+			// Exclude renderers incompatible with the geometry stage when writing to screen
+			#pragma exclude_renderers gles gles3 glcore
             #define GEOM_SUPPORT
             #include "./UI-Modified.cginc"
             ENDCG

--- a/Packages/idv.jlchntoz.vrcw-foundation/Shaders/UI-Modified.shader
+++ b/Packages/idv.jlchntoz.vrcw-foundation/Shaders/UI-Modified.shader
@@ -62,8 +62,8 @@ Shader "UI/Modified" {
             #pragma geometry geom
             #pragma fragment frag
             #pragma target 4.0
-			// Exclude renderers incompatible with the geometry stage when writing to screen
-			#pragma exclude_renderers gles gles3 glcore
+            // Exclude renderers incompatible with the geometry stage when writing to screen
+            #pragma exclude_renderers gles gles3 glcore
             #define GEOM_SUPPORT
             #include "./UI-Modified.cginc"
             ENDCG


### PR DESCRIPTION
Android VR headsets (e.g. Quest) do not support geometry stages when writing to screen. A black square is created in one eye instead.

This excludes this subshader from being active on quest (opengl targets) completely.